### PR TITLE
Update @typescript-eslint/array-type rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,9 @@ module.exports = {
 		'@typescript-eslint/adjacent-overload-signatures': 'error',
 		'@typescript-eslint/array-type': [
 			'error',
-			'array-simple'
+		        {
+				default: 'array-simple'
+		        }
 		],
 		'@typescript-eslint/await-thenable': 'error',
 		'@typescript-eslint/ban-types': [


### PR DESCRIPTION
Fixes this error:

```
Error: .eslintrc.json » eslint-config-xo-typescript:
        Configuration for rule "@typescript-eslint/array-type" is invalid:
        Value "array-simple" should be object.
```

Related change: https://github.com/typescript-eslint/typescript-eslint/pull/654