### PR TITLE
Make the '@typescript-eslint/explicit-function-return-type' rule lint .ts/.tsx files only

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,13 +103,6 @@ module.exports = {
 		// 	'type'
 		// ],
 
-		'@typescript-eslint/explicit-function-return-type': [
-			'error',
-			{
-				allowExpressions: true,
-				allowTypedFunctionExpressions: true
-			}
-		],
 		'@typescript-eslint/generic-type-naming': [
 			'error',
 			'^T$|^[A-Z][a-zA-Z]+$'
@@ -308,5 +301,19 @@ module.exports = {
 
 		// Disabled because of https://github.com/typescript-eslint/typescript-eslint/issues/60
 		'no-redeclare': 'off'
-	}
+	},
+	overrides: [
+		{
+			files: ['*.ts', '*.tsx'],
+			rules: {
+				'@typescript-eslint/explicit-function-return-type': [
+					'error',
+					{
+						allowExpressions: true,
+						allowTypedFunctionExpressions: true
+					}
+				]
+			}
+		}
+	]
 };


### PR DESCRIPTION
Current in a mixed JS/TS codebase (which is common), you will get unfixable lint errors reported within .js/.jsx files.

Documentation: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-function-return-type.md#configuring-in-a-mixed-jsts-codebase