### PR TITLE
Clarify usage with/without XO in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,11 @@
 $ npm install --save-dev eslint-config-xo eslint-config-xo-typescript @typescript-eslint/parser @typescript-eslint/eslint-plugin
 ```
 
-## Usage
+## Usage with XO
+
+[XO has built-in support for TypeScript](https://github.com/xojs/xo#typescript), by using this module under the hood by default, so you do not have to configure anything.
+
+## Standalone Usage
 
 Add some ESLint config to your package.json (or `.eslintrc`):
 
@@ -51,26 +55,6 @@ Use the `space` sub-config if you want 2 space indentation instead of tabs:
 		"parserOptions": {
 			"project": "some-path/tsconfig.json"
 		}
-	}
-}
-```
-
-## Tip
-
-### Use with XO
-
-```
-$ npm install --save-dev eslint-config-xo-typescript @typescript-eslint/parser @typescript-eslint/eslint-plugin
-```
-
-```json
-{
-	"name": "my-awesome-project",
-	"xo": {
-		"extends": "xo-typescript",
-		"extensions": [
-			"ts"
-		]
 	}
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ $ npm install --save-dev eslint-config-xo eslint-config-xo-typescript @typescrip
 
 ## Usage with XO
 
-[XO has built-in support for TypeScript](https://github.com/xojs/xo#typescript), by using this module under the hood by default, so you do not have to configure anything.
+[XO has built-in support for TypeScript](https://github.com/xojs/xo#typescript), using this package under the hood, so you do not have to configure anything.
 
 ## Standalone Usage
 


### PR DESCRIPTION
XO supports typescript by default now, without extra setup. The current "Use with XO" section is outdated.

I think. Right?

----

Inspired by [this commit in Got](https://github.com/sindresorhus/got/commit/3da16e02bcaecd05ae5df97d78e9188221dca466)