### PR TITLE
Update usage heading

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 $ npm install --save-dev eslint-config-xo eslint-config-xo-typescript @typescript-eslint/parser @typescript-eslint/eslint-plugin
 ```
 
-## Usage with XO
+## Use with XO
 
 [XO has built-in support for TypeScript](https://github.com/xojs/xo#typescript), using this package under the hood, so you do not have to configure anything.
 


### PR DESCRIPTION
[XO](https://github.com/xojs/xo#typescript-and-flow) links to eslint-config-xo-typescript via `use-with-xo`. This language seems to be standard across multiple repos referenced by the main repo. If `usage-with-xo` is desired then the main repo link could be updated instead 😌