### PR TITLE
Add `@typescript-eslint/no-redeclare` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -371,6 +371,8 @@ module.exports = {
 
 		'@typescript-eslint/no-non-null-asserted-optional-chain': 'error',
 		'@typescript-eslint/no-non-null-assertion': 'error',
+		'no-redeclare': 'off',
+		'@typescript-eslint/no-redeclare': 'error',
 
 		// TODO: Enable this again when I target ESM output in all my TypeScript projects
 		// '@typescript-eslint/no-require-imports': 'error',


### PR DESCRIPTION
Commit 025fcf453f7529cd95a2e7ec42f9b06e820c4793 said that `no-redeclare` has been fixed and removed `'no-redeclare': 'off'`.  But we still need the [typescript-eslint version](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-redeclare.md) of this rule, not the base rule.  For example, the base rule doesn’t support [overloads](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads):

```ts
export function f(x: number): number;
export function f(x: string): string;
export function f(x: number | string): number | string {
	return x;
}
```

```
  test.ts:2:17
  ✖  2:17  f is already defined.  no-redeclare
  ✖  3:17  f is already defined.  no-redeclare

  2 errors
```