### PR TITLE
Use default for `@typescript-eslint/promise-function-async`

### DIFF
--- a/index.js
+++ b/index.js
@@ -453,12 +453,7 @@ module.exports = {
 		'@typescript-eslint/prefer-reduce-type-parameter': 'error',
 		'@typescript-eslint/prefer-string-starts-ends-with': 'error',
 		'@typescript-eslint/prefer-ts-expect-error': 'error',
-		'@typescript-eslint/promise-function-async': [
-			'error',
-			{
-				allowAny: true
-			}
-		],
+		'@typescript-eslint/promise-function-async': 'error',
 		quotes: 'off',
 		'@typescript-eslint/quotes': [
 			'error',


### PR DESCRIPTION
This matches the default now (since v2 of the plugin)

https://github.com/typescript-eslint/typescript-eslint/blob/8cfe93372e1d826e54febc3aeb7047c792b90963/packages/eslint-plugin/src/rules/promise-function-async.ts#L66-L68