### PR TITLE
Revert `typescript` as `dependency`, make it a `devDependency` again

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,15 +43,13 @@
 		"hint",
 		"simple"
 	],
-	"dependencies": {
-		"typescript": ">=4.4"
-	},
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "^5.0.0",
 		"@typescript-eslint/parser": "^5.0.0",
 		"ava": "^2.4.0",
 		"eslint": "^7.8.1",
-		"temp-write": "^4.0.0"
+		"temp-write": "^4.0.0",
+		"typescript": ">=4.4"
 	},
 	"peerDependencies": {
 		"@typescript-eslint/eslint-plugin": ">=5.0.0",


### PR DESCRIPTION
Reverts https://github.com/xojs/eslint-config-xo-typescript/commit/2e16d51a8cdcd1e34a827fa8e782075888590062 which was added to try and fix the https://github.com/xojs/xo/issues/555 issue, but makes the actual fix for that (`bundledDependencies`) be crazy large as it will then needlessly include `typescript` as well