### PR TITLE
Use absolute path for keys in `'import/parsers'`

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = {
 			}
 		},
 		'import/parsers': {
-			'@typescript-eslint/parser': [
+			[require.resolve('@typescript-eslint/parser')]: [
 				'.ts',
 				'.tsx'
 			]


### PR DESCRIPTION
Fixes https://github.com/xojs/xo/pull/624#issuecomment-953547663 and these kind of errors there:

```
 ✖    2:16  Parse errors in imported module ../source: Cannot find module @typescript-eslint/parser
Require stack:
- /path/to/repo/ow/node_modules/eslint-module-utils/module-require.js
- /path/to/repo/ow/node_modules/eslint-module-utils/parse.js
- /path/to/repo/ow/node_modules/eslint-plugin-import/lib/ExportMap.js
- /path/to/repo/ow/node_modules/eslint-plugin-import/lib/rules/named.js
- /path/to/repo/ow/node_modules/eslint-plugin-import/lib/index.js
- /path/to/repo/ow/node_modules/@eslint/eslintrc/dist/eslintrc.cjs (undefined:undefined)                            import/no-named-as-default
```