### PR TITLE
Allow pascal-case in `.tsx` files

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,78 @@
 'use strict';
+const getNamingConventionRule = ({isTsx}) => ({
+	"@typescript-eslint/naming-convention": [
+	'error',
+	{
+		// selector: ['variableLike', 'memberLike', 'property', 'method'],
+		// Note: Leaving out `parameter` and `typeProperty` because of the mentioned known issues.
+		// Note: We are intentionally leaving out `enumMember` as it's usually pascal-case or upper-snake-case.
+		selector: ['variable', 'function', 'classProperty', 'objectLiteralProperty', 'parameterProperty', 'classMethod', 'objectLiteralMethod', 'typeMethod', 'accessor'],
+		format: [
+			'strictCamelCase',
+			isTsx && 'StrictPascalCase',
+		].filter(Boolean),
+		// We allow double underscope because of GraphQL type names and some React names.
+		leadingUnderscore: 'allowSingleOrDouble',
+		trailingUnderscore: 'allow',
+		// Ignore `{'Retry-After': retryAfter}` type properties.
+		filter: {
+			regex: '[- ]',
+			match: false
+		}
+	},
+	{
+		selector: 'typeLike',
+		format: [
+			'StrictPascalCase'
+		]
+	},
+	{
+		selector: 'variable',
+		types: [
+			'boolean'
+		],
+		format: [
+			'StrictPascalCase'
+		],
+		prefix: [
+			'is',
+			'has',
+			'can',
+			'should',
+			'will',
+			'did'
+		]
+	},
+	{
+		// Interface name should not be prefixed with `I`.
+		selector: 'interface',
+		filter: /^(?!I)[A-Z]/.source,
+		format: [
+			'StrictPascalCase'
+		]
+	},
+	{
+		// Type parameter name should either be `T` or a descriptive name.
+		selector: 'typeParameter',
+		filter: /^T$|^[A-Z][a-zA-Z]+$/.source,
+		format: [
+			'StrictPascalCase'
+		]
+	},
+	// Allow these in non-camel-case when quoted.
+	{
+		selector: [
+			'classProperty',
+			'objectLiteralProperty'
+		],
+		format: null,
+		modifiers: [
+			'requiresQuotes'
+		]
+	}
+	]
+})
+
 module.exports = {
 	parser: require.resolve('@typescript-eslint/parser'),
 	parserOptions: {
@@ -274,76 +348,7 @@ module.exports = {
 		// - https://github.com/typescript-eslint/typescript-eslint/issues/1485
 		// - https://github.com/typescript-eslint/typescript-eslint/issues/1484
 		// TODO: Prevent `_` prefix on private fields when TypeScript 3.8 is out.
-		'@typescript-eslint/naming-convention': [
-			'error',
-			{
-				// selector: ['variableLike', 'memberLike', 'property', 'method'],
-				// Note: Leaving out `parameter` and `typeProperty` because of the mentioned known issues.
-				// Note: We are intentionally leaving out `enumMember` as it's usually pascal-case or upper-snake-case.
-				selector: ['variable', 'function', 'classProperty', 'objectLiteralProperty', 'parameterProperty', 'classMethod', 'objectLiteralMethod', 'typeMethod', 'accessor'],
-				format: [
-					'strictCamelCase'
-				],
-				// We allow double underscope because of GraphQL type names and some React names.
-				leadingUnderscore: 'allowSingleOrDouble',
-				trailingUnderscore: 'allow',
-				// Ignore `{'Retry-After': retryAfter}` type properties.
-				filter: {
-					regex: '[- ]',
-					match: false
-				}
-			},
-			{
-				selector: 'typeLike',
-				format: [
-					'StrictPascalCase'
-				]
-			},
-			{
-				selector: 'variable',
-				types: [
-					'boolean'
-				],
-				format: [
-					'StrictPascalCase'
-				],
-				prefix: [
-					'is',
-					'has',
-					'can',
-					'should',
-					'will',
-					'did'
-				]
-			},
-			{
-				// Interface name should not be prefixed with `I`.
-				selector: 'interface',
-				filter: /^(?!I)[A-Z]/.source,
-				format: [
-					'StrictPascalCase'
-				]
-			},
-			{
-				// Type parameter name should either be `T` or a descriptive name.
-				selector: 'typeParameter',
-				filter: /^T$|^[A-Z][a-zA-Z]+$/.source,
-				format: [
-					'StrictPascalCase'
-				]
-			},
-			// Allow these in non-camel-case when quoted.
-			{
-				selector: [
-					'classProperty',
-					'objectLiteralProperty'
-				],
-				format: null,
-				modifiers: [
-					'requiresQuotes'
-				]
-			}
-		],
+		...getNamingConventionRule({isTsx: false}),
 		'@typescript-eslint/no-base-to-string': 'error',
 		'no-array-constructor': 'off',
 		'@typescript-eslint/no-array-constructor': 'error',
@@ -680,78 +685,7 @@ module.exports = {
 				'**/*.tsx'
 			],
 			rules: {
-				// NOTE: This is a copy of the above rule, and only allows StrictPascalCase.
-				'@typescript-eslint/naming-convention': [
-					'error',
-					{
-						// selector: ['variableLike', 'memberLike', 'property', 'method'],
-						// Note: Leaving out `parameter` and `typeProperty` because of the mentioned known issues.
-						// Note: We are intentionally leaving out `enumMember` as it's usually pascal-case or upper-snake-case.
-						selector: ['variable', 'function', 'classProperty', 'objectLiteralProperty', 'parameterProperty', 'classMethod', 'objectLiteralMethod', 'typeMethod', 'accessor'],
-						format: [
-							'strictCamelCase',
-							'StrictPascalCase'
-						],
-						// We allow double underscope because of GraphQL type names and some React names.
-						leadingUnderscore: 'allowSingleOrDouble',
-						trailingUnderscore: 'allow',
-						// Ignore `{'Retry-After': retryAfter}` type properties.
-						filter: {
-							regex: '[- ]',
-							match: false
-						}
-					},
-					{
-						selector: 'typeLike',
-						format: [
-							'StrictPascalCase'
-						]
-					},
-					{
-						selector: 'variable',
-						types: [
-							'boolean'
-						],
-						format: [
-							'StrictPascalCase'
-						],
-						prefix: [
-							'is',
-							'has',
-							'can',
-							'should',
-							'will',
-							'did'
-						]
-					},
-					{
-						// Interface name should not be prefixed with `I`.
-						selector: 'interface',
-						filter: /^(?!I)[A-Z]/.source,
-						format: [
-							'StrictPascalCase'
-						]
-					},
-					{
-						// Type parameter name should either be `T` or a descriptive name.
-						selector: 'typeParameter',
-						filter: /^T$|^[A-Z][a-zA-Z]+$/.source,
-						format: [
-							'StrictPascalCase'
-						]
-					},
-					// Allow these in non-camel-case when quoted.
-					{
-						selector: [
-							'classProperty',
-							'objectLiteralProperty'
-						],
-						format: null,
-						modifiers: [
-							'requiresQuotes'
-						]
-					}
-				],
+				...getNamingConventionRule({isTsx: true})
 			}
 		}
 	]

--- a/index.js
+++ b/index.js
@@ -674,6 +674,85 @@ module.exports = {
 				'@typescript-eslint/no-unsafe-call': 'off',
 				'@typescript-eslint/no-confusing-void-expression': 'off' // Conflicts with `expectError` assertion.
 			}
+		},
+		{
+			files: [
+				'**/*.tsx'
+			],
+			rules: {
+				// NOTE: This is a copy of the above rule, and only allows StrictPascalCase.
+				'@typescript-eslint/naming-convention': [
+					'error',
+					{
+						// selector: ['variableLike', 'memberLike', 'property', 'method'],
+						// Note: Leaving out `parameter` and `typeProperty` because of the mentioned known issues.
+						// Note: We are intentionally leaving out `enumMember` as it's usually pascal-case or upper-snake-case.
+						selector: ['variable', 'function', 'classProperty', 'objectLiteralProperty', 'parameterProperty', 'classMethod', 'objectLiteralMethod', 'typeMethod', 'accessor'],
+						format: [
+							'strictCamelCase',
+							'StrictPascalCase'
+						],
+						// We allow double underscope because of GraphQL type names and some React names.
+						leadingUnderscore: 'allowSingleOrDouble',
+						trailingUnderscore: 'allow',
+						// Ignore `{'Retry-After': retryAfter}` type properties.
+						filter: {
+							regex: '[- ]',
+							match: false
+						}
+					},
+					{
+						selector: 'typeLike',
+						format: [
+							'StrictPascalCase'
+						]
+					},
+					{
+						selector: 'variable',
+						types: [
+							'boolean'
+						],
+						format: [
+							'StrictPascalCase'
+						],
+						prefix: [
+							'is',
+							'has',
+							'can',
+							'should',
+							'will',
+							'did'
+						]
+					},
+					{
+						// Interface name should not be prefixed with `I`.
+						selector: 'interface',
+						filter: /^(?!I)[A-Z]/.source,
+						format: [
+							'StrictPascalCase'
+						]
+					},
+					{
+						// Type parameter name should either be `T` or a descriptive name.
+						selector: 'typeParameter',
+						filter: /^T$|^[A-Z][a-zA-Z]+$/.source,
+						format: [
+							'StrictPascalCase'
+						]
+					},
+					// Allow these in non-camel-case when quoted.
+					{
+						selector: [
+							'classProperty',
+							'objectLiteralProperty'
+						],
+						format: null,
+						modifiers: [
+							'requiresQuotes'
+						]
+					}
+				],
+			}
 		}
 	]
 };

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const getNamingConventionRule = ({isTsx}) => ({
 	"@typescript-eslint/naming-convention": [
 	'error',
@@ -11,7 +12,7 @@ const getNamingConventionRule = ({isTsx}) => ({
 			'strictCamelCase',
 			isTsx && 'StrictPascalCase',
 		].filter(Boolean),
-		// We allow double underscope because of GraphQL type names and some React names.
+		// We allow double underscore because of GraphQL type names and some React names.
 		leadingUnderscore: 'allowSingleOrDouble',
 		trailingUnderscore: 'allow',
 		// Ignore `{'Retry-After': retryAfter}` type properties.
@@ -71,7 +72,7 @@ const getNamingConventionRule = ({isTsx}) => ({
 		]
 	}
 	]
-})
+});
 
 module.exports = {
 	parser: require.resolve('@typescript-eslint/parser'),


### PR DESCRIPTION
Added override of `@typescript-eslint/naming-convention` rule for the tsx file.

When the rule was overridden, the internal options are not merged, so I just copied above rule.

I considered the detailed choices to allow the PascalCase for a while, but the component function could be used anywhere, I just added StrictPascalCase to origin rule.

If there is another opinion, I will reflect it in the PR.

resolve #48 