### PR TITLE
`@typescript-eslint/no-throw-literal`: Enable `allowThrowingUnknown` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -477,8 +477,7 @@ module.exports = {
 		'@typescript-eslint/no-throw-literal': [
 			'error',
 			{
-				allowThrowingAny: false,
-				allowThrowingUnknown: false
+				allowThrowingAny: false
 			}
 		],
 		'@typescript-eslint/no-unnecessary-boolean-literal-compare': 'error',

--- a/index.js
+++ b/index.js
@@ -477,6 +477,8 @@ module.exports = {
 		'@typescript-eslint/no-throw-literal': [
 			'error',
 			{
+				// This should ideally be `false`, but it makes rethrowing errors inconvenient. There should be a separate `allowRethrowingUnknown` option.
+				allowThrowingUnknown: true,
 				allowThrowingAny: false
 			}
 		],


### PR DESCRIPTION
This piece of configuration is currently blocking plain code like:
```js
try {
	sorry()
} catch (error) {
	if (isCanadian(error)) {
		return;
	}

	throw error; // ERROR error
}