### PR TITLE
fix: naming-convention for requiresQuotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,12 +72,6 @@ const getNamingConventionRule = ({isTsx}) => ({
 		},
 		// Allow these in non-camel-case when quoted.
 		{
-			selector: ['classProperty', 'objectLiteralProperty'],
-			format: null,
-			modifiers: ['requiresQuotes'],
-		},
-		// Allow these in non-camel-case when quoted.
-		{
 			selector: [
 				'classProperty',
 				'objectLiteralProperty'

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const getNamingConventionRule = ({isTsx}) => ({
 			/// selector: ['variableLike', 'memberLike', 'property', 'method'],
 			// Note: Leaving out `parameter` and `typeProperty` because of the mentioned known issues.
 			// Note: We are intentionally leaving out `enumMember` as it's usually pascal-case or upper-snake-case.
-			selector: ['variable', 'function', 'classProperty', 'objectLiteralProperty', 'parameterProperty', 'classMethod', 'objectLiteralMethod', 'typeMethod', 'accessor'],
+			selector: ['variable', 'function',  'parameterProperty', 'classMethod', 'objectLiteralMethod', 'typeMethod', 'accessor'],
 			format: [
 				'strictCamelCase',
 				isTsx && 'StrictPascalCase',
@@ -59,6 +59,22 @@ const getNamingConventionRule = ({isTsx}) => ({
 			format: [
 				'StrictPascalCase'
 			]
+		},
+		{
+			selector: ['classProperty', 'objectLiteralProperty'],
+			format: [
+				'strictCamelCase',
+				isTsx && 'StrictPascalCase',
+			].filter(Boolean),
+			// We allow double underscore because of GraphQL type names and some React names.
+			leadingUnderscore: 'allowSingleOrDouble',
+			trailingUnderscore: 'allow',
+		},
+		// Allow these in non-camel-case when quoted.
+		{
+			selector: ['classProperty', 'objectLiteralProperty'],
+			format: null,
+			modifiers: ['requiresQuotes'],
 		},
 		// Allow these in non-camel-case when quoted.
 		{


### PR DESCRIPTION
As the [documentation](https://typescript-eslint.io/rules/naming-convention#how-does-the-rule-automatically-order-selectors) said, `filter` has a higher priority than `modifiers`

Before this PR, `requiresQuotes` rule never got matched

```
{
  selector: ['variable', 'function', 'classProperty', 'objectLiteralProperty', 'parameterProperty', 'classMethod', 'objectLiteralMethod', 'typeMethod', 'accessor'],
  ...
  filter: { regex: '[- ]', match: false}
}
// below rule never got matched.
{
  selector: ['classProperty', 'objectLiteralProperty'],
  format: null,
  modifiers: ['requiresQuotes'],
}
```

Or can remove `filter: { regex: '[- ]', match: false }`, it's used by lots of selectors, so I'm not sure.

# Test Plain

```
const obj = {
  '.Button': {} // PASSED
  a_b: {}   // FAILED
}
```