### PR TITLE
Drop  `@typescript-eslint/no-implicit-any-catch` for `useUnknownInCatchVariables`

### DIFF
--- a/index.js
+++ b/index.js
@@ -440,7 +440,6 @@ module.exports = {
 			}
 		],
 		'@typescript-eslint/no-for-in-array': 'error',
-		'@typescript-eslint/no-implicit-any-catch': 'error',
 		'@typescript-eslint/no-inferrable-types': 'error',
 
 		// Disabled for now as it has too many false-positives.


### PR DESCRIPTION
The rule has been deprecated and it doesn't support `useUnknownInCatchVariables`

https://typescript-eslint.io/rules/no-implicit-any-catch/