### PR TITLE
Upgrade @typescript-eslint libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,15 +45,15 @@
 		"simple"
 	],
 	"devDependencies": {
-		"@typescript-eslint/eslint-plugin": "^6.21.0",
-		"@typescript-eslint/parser": "^6.21.0",
+		"@typescript-eslint/eslint-plugin": "^7.0.2",
+		"@typescript-eslint/parser": "^7.0.2",
 		"ava": "^2.4.0",
 		"eslint": "^8.56.0",
 		"typescript": "^5.3.3"
 	},
 	"peerDependencies": {
-		"@typescript-eslint/eslint-plugin": ">=6.21.0",
-		"@typescript-eslint/parser": ">=6.21.0",
+		"@typescript-eslint/eslint-plugin": ">=7.0.2",
+		"@typescript-eslint/parser": ">=7.0.2",
 		"eslint": ">=8.56.0",
 		"typescript": ">=5.0.0"
 	}


### PR DESCRIPTION
The goal of this PR is to upgrade the @typescript-eslint libraries to the latest.

One reason is described here in the issue [Conflicts with @typescript-eslint libraries](https://github.com/xojs/eslint-config-xo-typescript/issues/81).

Does it make sense?

Fixes #81