### PR TITLE
Deactivate default-case rule to avoid conflict with stricter @typescript-eslint/switch-exhaustiveness-check

### DIFF
--- a/index.js
+++ b/index.js
@@ -677,7 +677,8 @@ module.exports = {
 		// 		allowSafe: true
 		// 	}
 		// ],
-
+		
+		'default-case': 'off',
 		'@typescript-eslint/switch-exhaustiveness-check': [
 			'error',
 			{


### PR DESCRIPTION
Fixes #80