### PR TITLE
Fix config array not being consumed properly in space config

### DIFF
--- a/space.js
+++ b/space.js
@@ -1,12 +1,9 @@
 import eslintConfigXo from './index.js';
 
-const [config] = eslintConfigXo;
-
 export default [
+	...eslintConfigXo,
 	{
-		...config,
 		rules: {
-			...config.rules,
 			'@stylistic/indent': [
 				'error',
 				2,


### PR DESCRIPTION
Was wondering why I wasn't seeing any TS eslint rules being enforced in one of my projects. Problematic line was 
```js
const [config] = eslintConfigXo;
```
which left out all the other config objects from the space config. 