### PR TITLE
erasableSyntaxOnly does not work with parameter properties shorthand

### DIFF
--- a/index.js
+++ b/index.js
@@ -531,12 +531,7 @@ const rules = {
 	],
 	'@typescript-eslint/no-wrapper-object-types': 'error',
 	'@typescript-eslint/non-nullable-type-assertion-style': 'error',
-	'@typescript-eslint/parameter-properties': [
-		'error',
-		{
-			prefer: 'parameter-property'
-		}
-	],
+	'@typescript-eslint/parameter-properties': 'error',
 	'@typescript-eslint/prefer-as-const': 'error',
 	'@typescript-eslint/prefer-find': 'error',
 	'@typescript-eslint/prefer-for-of': 'error',

--- a/index.js
+++ b/index.js
@@ -475,7 +475,6 @@ const rules = {
 	// 	}
 	// ],
 
-	'@typescript-eslint/no-unnecessary-parameter-property-assignment': 'error',
 	'@typescript-eslint/no-unnecessary-qualifier': 'error',
 	'@typescript-eslint/no-unnecessary-type-arguments': 'error',
 	'@typescript-eslint/no-unnecessary-type-assertion': 'error',
@@ -531,7 +530,6 @@ const rules = {
 	],
 	'@typescript-eslint/no-wrapper-object-types': 'error',
 	'@typescript-eslint/non-nullable-type-assertion-style': 'error',
-	'@typescript-eslint/parameter-properties': 'error',
 	'@typescript-eslint/prefer-as-const': 'error',
 	'@typescript-eslint/prefer-find': 'error',
 	'@typescript-eslint/prefer-for-of': 'error',


### PR DESCRIPTION
This rule by default disallows the usage of the parameter properties shorthand.

This rule could also be removed as typescript configured with erasableSyntaxOnly will also error on this.